### PR TITLE
Add missing vertica-python dependency and bump the version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sagemaker-studio" %}
-{% set version = "1.1.15" %}
+{% set version = "1.1.19" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/sagemaker_studio-{{ version }}.tar.gz
-  sha256: 8c0a8994fa2876b25d0c0ff1413a83da456a291f29634ba3b85becb9e074f3ea
+  sha256: 6c0d8f74f93972c3670c436790794ecd1c7ff0940dec20d1ab4bd3be39ed49c5
 
 build:
   noarch: python
@@ -51,6 +51,7 @@ requirements:
     - deltalake >=1.0.0
     - sqlglot >=27.28.1
     - opensearch-py >=2.5.0
+    - vertica-python >=1.4.0
 
 test:
   imports:


### PR DESCRIPTION
Add missing vertica-python dependency and bump the version to 1.1.19

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
